### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,9 @@ function unflatten(data) {
     do {
       idx = indexOf.call(p, ".", last)
       temp = p.substring(last, ~idx ? idx : undefined)
-      cur = cur[prop] || (cur[prop] = (!isNaN(parseInt(temp)) ? [] : {} && isPrototypePolluted(prop)))
+      if (isPrototypePolluted(prop))
+        continue
+      cur = cur[prop] || (cur[prop] = (!isNaN(parseInt(temp)) ? [] : {}))
       prop = temp
       last = idx + 1
     } while(idx >= 0)

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function unflatten(data) {
     do {
       idx = indexOf.call(p, ".", last)
       temp = p.substring(last, ~idx ? idx : undefined)
-      cur = cur[prop] || (cur[prop] = (!isNaN(parseInt(temp)) ? [] : {}))
+      cur = cur[prop] || (cur[prop] = (!isNaN(parseInt(temp)) ? [] : {} && isPrototypePolluted(prop)))
       prop = temp
       last = idx + 1
     } while(idx >= 0)
@@ -220,6 +220,10 @@ function getObjectsDiff(objectA, objectB, sortKeysFlag, flattenFlag) {
       return unflattened
     }
   }
+}
+
+function isPrototypePolluted(key) {
+  return ['__proto__', 'constructor', 'prototype'].includes(key)
 }
 
 var nestedObjectsUtil = {


### PR DESCRIPTION
### :bar_chart: Metadata *

`nested-objects-util` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-nested-objects-util

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var {unflatten} = require("nested-objects-util")
console.log("Before : " + {}.polluted);
unflatten({"__proto__.polluted": "Yes! Its Polluted"})
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i nested-objects-util # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/102757260-0fda0080-4397-11eb-9cf1-e5d6af9b5a23.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
